### PR TITLE
Pick timer fixups

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node-fetch": "^1.0.3",
     "send": "^0.11.1",
     "traceur": "0.0.65",
-    "utils": "git://github.com/aeosynth/utils"
+    "utils": "git://github.com/arxanas/utils"
   },
   "devDependencies": {
     "normalize.css": "^3.0.1",

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -35,7 +35,8 @@ let App = {
     packs: 3,
 
     bots: true,
-    timer: 40,
+    useTimer: true,
+    timerLength: 40, // seconds
 
     beep: false,
     chat: true,

--- a/public/src/cards.js
+++ b/public/src/cards.js
@@ -390,6 +390,13 @@ function Key(groups, sort) {
   return o
 }
 
+function sortLandsBeforeNonLands(lhs, rhs) {
+  let isLand = x => x.type.toLowerCase().indexOf('land') !== -1
+  let lhsIsLand = isLand(lhs)
+  let rhsIsLand = isLand(rhs)
+  return rhsIsLand - lhsIsLand
+}
+
 export function getZone(zoneName) {
   let zone = Zones[zoneName]
 
@@ -401,7 +408,7 @@ export function getZone(zoneName) {
   let {sort} = App.state
   let groups = _.group(cards, sort)
   for (let key in groups)
-    _.sort(groups[key], 'color', 'cmc', 'name')
+    _.sort(groups[key], sortLandsBeforeNonLands, 'color', 'cmc', 'name')
 
   groups = Key(groups, sort)
 

--- a/public/src/cards.js
+++ b/public/src/cards.js
@@ -93,8 +93,8 @@ let events = {
     App.send('readyToStart', e.target.checked)
   },
   start() {
-    let {bots, timer} = App.state
-    let options = [bots, timer]
+    let {bots, useTimer, timerLength} = App.state
+    let options = {bots, useTimer, timerLength}
     App.send('start', options)
   },
   pack(cards) {

--- a/public/src/components/deck-settings.js
+++ b/public/src/components/deck-settings.js
@@ -12,7 +12,7 @@ function Lands() {
     let inputs = BASICS.map(cardName =>
       d.td({},
         d.input({
-          className: 'num-lands',
+          className: 'number',
           min: 0,
           onChange: App._emit('land', zoneName, cardName),
           type: 'number',
@@ -27,7 +27,7 @@ function Lands() {
   let suggest = d.tr({},
     d.td({}, 'deck size'),
     d.td({}, d.input({
-      className: 'num-lands',
+      className: 'number',
       min: 0,
       onChange: App._emit('deckSize'),
       type: 'number',

--- a/public/src/components/game.js
+++ b/public/src/components/game.js
@@ -69,12 +69,22 @@ export default React.createClass({
     let startControls = d.div({},
       d.div({}, `Format: ${App.state.format}`),
       LBox('bots', 'bots'),
-      d.div({}, d.input({
-        min: 0,
-        max: 60,
-        type: 'number',
-        valueLink: App.link('timer'),
-        }), ' second timer'),
+      d.div({},
+        d.label({},
+          d.input({
+            type: 'checkbox',
+            checkedLink: App.link('useTimer'),
+          }), ' use '),
+        d.label({},
+          d.input({
+            className: 'number',
+            disabled: !App.state.useTimer,
+            min: 0,
+            max: 60,
+            step: 5,
+            type: 'number',
+            valueLink: App.link('timerLength'),
+          }), '-second timer')),
       d.div({}, startButton, readyReminderText))
 
     return d.fieldset({ className: 'start-controls fieldset' },

--- a/public/style.css
+++ b/public/style.css
@@ -109,6 +109,10 @@ input[type=button]:disabled:active, button:disabled:active {
   box-shadow: 0 0 1px 0 black inset;
 }
 
+.number {
+  width: 50px;
+}
+
 /** Container of inputs that share a border. **/
 
 .connected-container, .connected-column {
@@ -394,10 +398,6 @@ input[type=button]:disabled:active, button:disabled:active {
 
 .game-settings {
   flex-shrink: 0;
-}
-
-.num-lands {
-  width: 50px;
 }
 
 .deck-settings tr:first-of-type {

--- a/src/game.js
+++ b/src/game.js
@@ -307,7 +307,7 @@ module.exports = class Game extends Room {
     this.meta()
   }
 
-  start([addBots, useTimer]) {
+  start({addBots, useTimer, timerLength}) {
     var src = this.cube ? this.cube : this.sets
     var {players} = this
     var p
@@ -329,8 +329,12 @@ module.exports = class Game extends Room {
       return
     }
 
-    for (p of players)
+    timerLength = parseInt(timerLength, 10)
+    useTimer = !Number.isNaN(timerLength) && (timerLength > 0) && useTimer
+    for (p of players) {
       p.useTimer = useTimer
+      p.timerLength = timerLength
+    }
 
     console.log(`game ${this.id} started with ${this.players.length} players and ${this.seats} seats`)
     Game.broadcastGameInfo()

--- a/src/human.js
+++ b/src/human.js
@@ -69,8 +69,8 @@ module.exports = class extends EventEmitter {
     if (pack.length === 1)
       return this.pick(0)
 
-    if (this.useTimer > 0)
-      this.time = parseInt(this.useTimer) + parseInt(pack.length)
+    if (this.useTimer)
+      this.time = this.timerLength + pack.length
 
     this.send('pack', pack)
   }

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -275,16 +275,13 @@ function doCard(rawCard, cards, code, set) {
 
   if (rawCard.layout === 'split')
     name = rawCard.names.join(' // ')
-    
-  //separate landsfrom 0cmc cards by setting 0cmc to .2
-  var cmcadjusted = rawCard.cmc || 0.2
 
   name = _.ascii(name)
 
   if (name in cards) {
     if (rawCard.layout === 'split') {
       var card = cards[name]
-      cmcadjusted = card.cmc + rawCard.cmc
+      card.cmc += rawCard.cmc
       if (card.color !== rawCard.color)
         card.color = 'multicolor'
     }
@@ -295,15 +292,11 @@ function doCard(rawCard, cards, code, set) {
   var color = !colors ? 'colorless' :
     colors.length > 1 ? 'multicolor' :
     colors[0].toLowerCase()
-    
-  //set lands to .1 to sort them before nonland 0cmc  
-  if ('Land'.indexOf(rawCard.types) > -1)
-    cmcadjusted = 0.1
 
   cards[name] = { color, name,
     manaCost: rawCard.manaCost,
     type: rawCard.types[rawCard.types.length - 1],
-    cmc: cmcadjusted, 
+    cmc: rawCard.cmc || 0,
     text: rawCard.text || '',
     manaCost: rawCard.manaCost || '',
     sets: {


### PR DESCRIPTION
Integrates your changes with my PR feedback. Looks like this now:

<img width="427" alt="screen shot 2016-06-05 at 22 32 10" src="https://cloud.githubusercontent.com/assets/454057/15812753/670b17d2-2b6d-11e6-913e-93476118ae52.png">

I also changed the way the lands are sorted. I think it could be a bad idea to modify the actual CMCs. For example, if we ever get more intelligent draft bots, they would probably look at the CMC and not behave correctly because `0.1` and `0.2` aren't real values. Good idea though 👍.

Note that this updates the dependencies in `package.json`, so you may have to be careful about `npm install`ing to make sure you get my version of `utils`.