### PR TITLE
Bugfix: Prevent crashes when sock.h is undefined

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -157,7 +157,6 @@ module.exports = class Game extends Room {
   }
 
   join(sock) {
-    sock.on('exit', this.farewell.bind(this))
     for (var i = 0; i < this.players.length; i++) {
       var p = this.players[i]
       if (p.id === sock.id) {
@@ -208,11 +207,6 @@ module.exports = class Game extends Room {
       self: this.players.indexOf(h),
       format: this.format,
     })
-  }
-
-  farewell(sock) {
-    sock.h.isConnected = false
-    this.meta()
   }
 
   exit(sock) {

--- a/src/human.js
+++ b/src/human.js
@@ -31,6 +31,7 @@ module.exports = class extends EventEmitter {
     sock.on('autopick', this._autopick.bind(this))
     sock.on('pick', this._pick.bind(this))
     sock.on('hash', this._hash.bind(this))
+    sock.once('exit', this._farewell.bind(this))
 
     var [pack] = this.packs
     if (pack)
@@ -45,6 +46,10 @@ module.exports = class extends EventEmitter {
       return
 
     this.hash = hash(deck)
+    this.emit('meta')
+  }
+  _farewell() {
+    this.isConnected = false
     this.emit('meta')
   }
   _readyToStart(value) {


### PR DESCRIPTION
Occasionally there is a crash because sock.h is undefined when trying
to mark a player as disconnected. It's unclear to me why this is
happening, but theoretically this commit should prevent this situation
from happening as we should now always have a `.h` on hand.